### PR TITLE
Use a WeakMap and fix memory leak

### DIFF
--- a/dist/reactKeypress.js
+++ b/dist/reactKeypress.js
@@ -57,7 +57,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	"use strict";
 
 	var Keypress = __webpack_require__(1);
-	var elements = [];
+	var elements = new WeakMap();
 
 	module.exports = function (keys, handler) {
 		if (!keys || !handler) return;
@@ -66,11 +66,11 @@ return /******/ (function(modules) { // webpackBootstrap
 			var el = e.target;
 
 			//Check for no register the same element multiple times
-			if (elements.indexOf(el) >= 0) return;
+			if (elements.has(el)) return;
 
 			var listener = new Keypress.Listener(el);
 
-			elements.push(el);
+			elements.set(el, true);
 			listener.register_combo({
 				"keys": keys,
 				"on_keyup": handler

--- a/react-keypress.js
+++ b/react-keypress.js
@@ -1,5 +1,5 @@
 var Keypress = require("./bower_components/Keypress/keypress.js");
-var elements = [];
+var elements = new WeakMap();
 
 module.exports = function(keys, handler) {
 	if (!keys || !handler) return;
@@ -8,11 +8,11 @@ module.exports = function(keys, handler) {
 		var el = e.target;
 
 		//Check for no register the same element multiple times
-		if (elements.indexOf(el) >= 0) return;
+		if (elements.has(el)) return;
 
 		var listener = new Keypress.Listener(el);
 
-		elements.push(el);
+		elements.set(el, true);
 		listener.register_combo({
 			"keys": keys,
 			"on_keyup": handler


### PR DESCRIPTION
Pretty sure the current code has a memory leak in it since nothing is removing DOM elements from the `elements` array. Using a `WeakMap` instead of an array should properly deal with this leak.

Thanks!